### PR TITLE
Fix BigDecimal enter() behavior

### DIFF
--- a/app/src/main/java/com/example/reversecalculator/BigDecimalCalculator.java
+++ b/app/src/main/java/com/example/reversecalculator/BigDecimalCalculator.java
@@ -48,7 +48,7 @@ public class BigDecimalCalculator implements CalculatorInterface {
     @Override
     public void enter() {
         stack.push(buffer);
-        enter = true;
+        resetBuffer();
     }
 
     @Override

--- a/app/src/test/java/com/example/reversecalculator/BigDecimalCalculatorTest.java
+++ b/app/src/test/java/com/example/reversecalculator/BigDecimalCalculatorTest.java
@@ -133,7 +133,7 @@ public class BigDecimalCalculatorTest {
         calc.input('2');
         calc.enter();
         calc.calculate(Operator.MUL);
-        Assert.assertEquals("4", calc.getBuffer());
+        Assert.assertEquals("0", calc.getBuffer());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- clear BigDecimal buffer after pushing value to stack
- update unit test for new behaviour

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68710808eee0832e948fa38d69bf78c0