### PR TITLE
Add stack display to calculator view

### DIFF
--- a/app/src/main/java/com/example/reversecalculator/BasicCalculator.java
+++ b/app/src/main/java/com/example/reversecalculator/BasicCalculator.java
@@ -79,4 +79,9 @@ public class BasicCalculator implements CalculatorInterface {
         resetBuffer();
         stack = new Stack<>();
     }
+
+    @Override
+    public String getBufferState() {
+        return stack.toString();
+    }
 }

--- a/app/src/main/java/com/example/reversecalculator/BigDecimalCalculator.java
+++ b/app/src/main/java/com/example/reversecalculator/BigDecimalCalculator.java
@@ -103,4 +103,9 @@ public class BigDecimalCalculator implements CalculatorInterface {
         resetBuffer();
         stack = new Stack<>();
     }
+
+    @Override
+    public String getBufferState() {
+        return stack.toString();
+    }
 }

--- a/app/src/main/java/com/example/reversecalculator/CalculatorInterface.java
+++ b/app/src/main/java/com/example/reversecalculator/CalculatorInterface.java
@@ -17,6 +17,13 @@ public interface CalculatorInterface {
     String getBuffer();
 
     /**
+     * Return the current buffer state, e.g. the stack contents.
+     *
+     * @return a textual representation of the stack
+     */
+    String getBufferState();
+
+    /**
      * Push the buffer in the stack.
      */
     void enter();

--- a/app/src/main/java/com/example/reversecalculator/MainActivity.java
+++ b/app/src/main/java/com/example/reversecalculator/MainActivity.java
@@ -9,6 +9,7 @@ import android.widget.TextView;
 public class MainActivity extends AppCompatActivity {
 
     private TextView buffer;
+    private TextView state;
     private CalculatorInterface calc;
 
     @Override
@@ -17,11 +18,13 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
         calc = new BigDecimalCalculator();
         buffer = findViewById(R.id.buffer);
+        state = findViewById(R.id.state);
         updateBuffer();
     }
 
     private void updateBuffer() {
         buffer.setText(calc.getBuffer());
+        state.setText(calc.getBufferState());
     }
 
     public void enter(View view) {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,13 +7,24 @@
     tools:context=".MainActivity">
 
     <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/state"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="end"
+        android:padding="8dp"
+        android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/buffer"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:gravity="end"
         android:padding="24dp"
         android:textAppearance="@style/TextAppearance.Material3.DisplayLarge"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/state"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -12,6 +12,7 @@
         android:layout_height="wrap_content"
         android:gravity="end"
         android:padding="8dp"
+        android:layout_marginTop="16dp"
         android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
## Summary
- show the stack on screen above the buffer
- expose stack via `getBufferState()` in `CalculatorInterface`
- implement the new API in both calculators
- update `MainActivity` to keep the stack view in sync

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68739cd431a8832e83e6811de40be735