### PR TITLE
Fix button text size in landscape

### DIFF
--- a/app/src/main/res/values-land/dimens.xml
+++ b/app/src/main/res/values-land/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+    <dimen name="calc_button_text_size">18sp</dimen>
+</resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+    <dimen name="calc_button_text_size">24sp</dimen>
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -11,7 +11,7 @@
         <item name="android:layout_height">match_parent</item>
         <item name="android:layout_weight">1</item>
         <item name="android:layout_margin">4dp</item>
-        <item name="android:textSize">24sp</item>
+        <item name="android:textSize">@dimen/calc_button_text_size</item>
         <item name="android:textColor">@color/calcButtonText</item>
     </style>
 


### PR DESCRIPTION
## Summary
- make button text size a dimension
- override the dimension in landscape to keep text visible

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873a382418c832ea2bb4e5f3e44220b