### PR TITLE
Update package namespace to org.frugo

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    namespace "com.example.reversecalculator"
+    namespace "org.frugo.reversecalculator"
     compileSdkVersion 35
     buildToolsVersion "35.0.0"
     defaultConfig {
-        applicationId "com.example.reversecalculator"
+        applicationId "org.frugo.reversecalculator"
         minSdkVersion 21
         targetSdkVersion 35
         versionCode 1

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.reversecalculator">
+    package="org.frugo.reversecalculator">
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/org/frugo/reversecalculator/BasicCalculator.java
+++ b/app/src/main/java/org/frugo/reversecalculator/BasicCalculator.java
@@ -1,4 +1,4 @@
-package com.example.reversecalculator;
+package org.frugo.reversecalculator;
 
 import java.util.EmptyStackException;
 import java.util.Stack;

--- a/app/src/main/java/org/frugo/reversecalculator/BigDecimalCalculator.java
+++ b/app/src/main/java/org/frugo/reversecalculator/BigDecimalCalculator.java
@@ -1,4 +1,4 @@
-package com.example.reversecalculator;
+package org.frugo.reversecalculator;
 
 import java.math.BigDecimal;
 import java.math.MathContext;

--- a/app/src/main/java/org/frugo/reversecalculator/CalculatorInterface.java
+++ b/app/src/main/java/org/frugo/reversecalculator/CalculatorInterface.java
@@ -1,4 +1,4 @@
-package com.example.reversecalculator;
+package org.frugo.reversecalculator;
 
 public interface CalculatorInterface {
 

--- a/app/src/main/java/org/frugo/reversecalculator/MainActivity.java
+++ b/app/src/main/java/org/frugo/reversecalculator/MainActivity.java
@@ -1,4 +1,4 @@
-package com.example.reversecalculator;
+package org.frugo.reversecalculator;
 
 import androidx.appcompat.app.AppCompatActivity;
 

--- a/app/src/main/java/org/frugo/reversecalculator/Operator.java
+++ b/app/src/main/java/org/frugo/reversecalculator/Operator.java
@@ -1,4 +1,4 @@
-package com.example.reversecalculator;
+package org.frugo.reversecalculator;
 
 public enum Operator {
     ADD, SUB, MUL, DIV

--- a/app/src/test/java/org/frugo/reversecalculator/BasicCalculatorTest.java
+++ b/app/src/test/java/org/frugo/reversecalculator/BasicCalculatorTest.java
@@ -1,4 +1,4 @@
-package com.example.reversecalculator;
+package org.frugo.reversecalculator;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/app/src/test/java/org/frugo/reversecalculator/BigDecimalCalculatorTest.java
+++ b/app/src/test/java/org/frugo/reversecalculator/BigDecimalCalculatorTest.java
@@ -1,4 +1,4 @@
-package com.example.reversecalculator;
+package org.frugo.reversecalculator;
 
 import org.junit.Assert;
 import org.junit.Before;


### PR DESCRIPTION
## Summary
- change Android namespace and application id to `org.frugo`
- move Java classes into the new `org.frugo.reversecalculator` package
- update package declarations in code and tests
- adjust manifest package

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875022076dc832ea1a8326b5ff167ae